### PR TITLE
small fix in HolesByGenrators

### DIFF
--- a/gap/affine-def.gi
+++ b/gap/affine-def.gi
@@ -301,6 +301,8 @@ InstallMethod(Gaps,
       if (Gcd(S[j])<>1) then
         Error("This affine semigroup has infinitely many gaps");
       fi;
+  od;
+  for j in [1..Length(A[1])] do
       if FrobeniusNumber(NumericalSemigroup(S[j]))=-1 then
       sum:=0;
       else


### PR DESCRIPTION
Without the two lines introduced it gives as message of error "The greatest common divisor is 1" but it should give "This affine semigroup has infinitely many gaps"