### PR TITLE
New functions for Affine Semigroups

### DIFF
--- a/doc/contributions.xml
+++ b/doc/contributions.xml
@@ -189,7 +189,13 @@ He also helped in preliminary versions of the following functions.
 
 
 <Section><Heading>Functions implemented by C. Cisto</Heading>
-  Carmelo provided some preliminary functions to deal with affine semigroups given by gaps, and to compute gaps of affine semigroups with finite genus, see for instance <Ref Func="AffineSemigroupByGaps"/>.
+  Carmelo provided some functions to deal with affine semigroups given by gaps, and to compute gaps of affine semigroups with finite genus, see for instance 
+  <P/>
+    <Ref Func="AffineSemigroupByGaps"/>,
+  <P/>
+    <Ref Func="RemoveMinimalGeneratorFromAffineSemigroup">,
+  <P/>
+    <Ref Func="AddSpecialGapOfAffineSemigroup">.
 
 </Section>
 

--- a/gap/affine-def.gd
+++ b/gap/affine-def.gd
@@ -75,7 +75,24 @@ DeclareAttribute("PseudoFrobenius", IsAffineSemigroup);
 ###############################################################################
 DeclareAttribute("SpecialGaps", IsAffineSemigroup);
 
+###############################################################################
+#
+# RemoveMinimalGeneratorFromAffineSemigroup(x,s)
+#
+# Compute the affine semigroup obtained by removing the minimal generator x from 
+# the given affine semigroup s. If s has finite gaps, its set of gaps is setted 
+# 
+###############################################################################
+DeclareGlobalFunction("RemoveMinimalGeneratorFromAffineSemigroup");
 
+############################################################################## 
+#
+#  AddSpecialGapOfAffineSemigroup(x,s)
+#
+# Let a an affine semigroup with finite gaps and x be a special gap of a.
+# We compute the unitary extension of a with x
+################################################################################
+DeclareGlobalFunction("AddSpecialGapOfAffineSemigroup");
 
 #############################################################################
 ##

--- a/gap/affine-def.gi
+++ b/gap/affine-def.gi
@@ -751,7 +751,7 @@ InstallGlobalFunction(AddSpecialGapOfAffineSemigroup, function( x, a )
     Error("The first argument must be a list of non negative integers.\n");
   fi;
 
-  if(not(IsAffineSemigroup(s))) then
+  if(not(IsAffineSemigroup(a))) then
     Error("The second argument must be an affine semigroup.\n");
   fi;
   

--- a/gap/affine-def.gi
+++ b/gap/affine-def.gi
@@ -763,7 +763,7 @@ InstallGlobalFunction(AddSpecialGapOfAffineSemigroup, function( x, a )
     SetGaps(s,H);
     return s;
   else
-    Error(x," must be a special gap of ",s,".\n");  
+    Error(x," must be a special gap of ",a,".\n");  
   fi;
 end);
 

--- a/gap/affine-def.gi
+++ b/gap/affine-def.gi
@@ -701,6 +701,71 @@ function(s)
 
 end);
 
+###############################################################################
+#
+# RemoveMinimalGeneratorFromAffineSemigroup(x,s)
+#
+# Compute the affine semigroup obtained by removing the minimal generator x from 
+# the given affine semigroup s. If s has finite gaps, its set of gaps is setted 
+# 
+#################################################################################
+InstallGlobalFunction(RemoveMinimalGeneratorFromAffineSemigroup, function(x,s)
+  local H,t,gens;
+
+  if not(ForAll(x,i -> (IsPosInt(i) or i = 0))) then
+    Error("The first argument must be a list of non negative integers.\n");
+  fi;
+
+  if(not(IsAffineSemigroup(s))) then
+    Error("The second argument must be an affine semigroup.\n");
+  fi;
+
+  gens:=MinimalGenerators(s);
+  if x in gens then
+    gens:=Difference(gens,[x]);
+    gens:=Union(gens,gens+x);
+    gens:=Union(gens,[2*x,3*x]);
+    t:=AffineSemigroup(gens);
+    if HasGaps(s) then
+      H:=Gaps(s);
+      H:=Union(H,[x]);
+      SetGaps(t,H);
+    fi;  
+    return t;
+  else
+    return Error(x," must be a minimal generator of ",s,".\n");
+  fi;
+end);
+
+############################################################################## 
+#
+#  AddSpecialGapOfAffineSemigroup(x,s)
+#
+# Let a an affine semigroup with finite gaps and x be a special gap of a.
+# We compute the unitary extension of a with x.
+################################################################################
+InstallGlobalFunction(AddSpecialGapOfAffineSemigroup, function( x, a )
+  local H,s,gens;
+
+  if not(ForAll(x,i -> (IsPosInt(i) or i = 0))) then
+    Error("The first argument must be a list of non negative integers.\n");
+  fi;
+
+  if(not(IsAffineSemigroup(s))) then
+    Error("The second argument must be an affine semigroup.\n");
+  fi;
+  
+  H:=Set(Gaps(a));
+  if x in SpecialGaps(a) then
+    RemoveSet(H,x);
+    gens:=Union(Generators(a),[x]);
+    s:=AffineSemigroup(gens);
+    SetGaps(s,H);
+    return s;
+  else
+    Error(x," must be a special gap of ",s,".\n");  
+  fi;
+end);
 
 #############################################################################
 ##


### PR DESCRIPTION
Two new functions are provided:
1. "RemoveMinimalGeneratorsFromAffineSemigroup" to obtain an affine semigroup by removing a minimal generator to another given affine semigroup
gap> a:=AffineSemigroup([2,0],[0,4]);
\<Affine semigroup in 2 dimensional space, with 2 generators>
gap> b:=RemoveMinimalGeneratorFromAffineSemigroup([2,0],a);Generators(b);
\<Affine semigroup in 2 dimensional space, with 4 generators>
[ [ 0, 4 ], [ 2, 4 ], [ 4, 0 ], [ 6, 0 ] ]

2. "AddSpecialGapOfAffineSemigroup", it works for affine semigroups with gaps and compute the affine semigroup obtained adding a special gap.
gap> s:=AffineSemigroup([[2,0],[3,0],[0,4],[0,5],[1,1]]);
\<Affine semigroup in 2 dimensional space, with 5 generators>
gap> t:=AddSpecialGapOfAffineSemigroup([1,12],s);
\<Affine semigroup in 2 dimensional space, with 6 generators>
gap> Gaps(s);
[ [ 0, 1 ], [ 0, 2 ], [ 0, 3 ], [ 0, 6 ], [ 0, 7 ], [ 0, 11 ], [ 1, 0 ], [ 1, 2 ], [ 1, 3 ], [ 1, 4 ],
  [ 1, 7 ], [ 1, 8 ], [ 1, 12 ], [ 2, 1 ], [ 2, 3 ], [ 3, 2 ], [ 4, 3 ] ]
gap> Gaps(t);
[ [ 0, 1 ], [ 0, 2 ], [ 0, 3 ], [ 0, 6 ], [ 0, 7 ], [ 0, 11 ], [ 1, 0 ], [ 1, 2 ], [ 1, 3 ], [ 1, 4 ],
  [ 1, 7 ], [ 1, 8 ], [ 2, 1 ], [ 2, 3 ], [ 3, 2 ], [ 4, 3 ] ]

The file contributions.xml has been modified