### PR TITLE
Apery sets for non-minimal generating sets

### DIFF
--- a/gap/basics.gi
+++ b/gap/basics.gi
@@ -739,10 +739,10 @@ InstallMethod( AperyListOfNumericalSemigroupWRTElement,
         nonmults := Difference(msg,[m]);
         ret := ListWithIdenticalEntries(m,infinity);
 
-        ret[1] := 0;
-        for g in nonmults do
+        for g in Reversed(nonmults) do
             ret[(g mod m)+1] := g;
         od;
+        ret[1] := 0;
 
         curround := List(nonmults);
 

--- a/gap/basics.gi
+++ b/gap/basics.gi
@@ -735,7 +735,7 @@ InstallMethod( AperyListOfNumericalSemigroupWRTElement,
     if not BelongsToNumericalSemigroup(m,s) then
         Error("The second argument  must be an element of the first argument");
     else
-        msg := MinimalGeneratingSystemOfNumericalSemigroup(s);
+        msg := Generators(s);
         nonmults := Difference(msg,[m]);
         ret := ListWithIdenticalEntries(m,infinity);
 


### PR DESCRIPTION
Fixed an issue with AperyListOfNumericalSemigroupWRTElement when working with non-minimal generating sets.  
'''
gap> s := NumericalSemigroup(3,5,6);
<Numerical semigroup with 3 generators>
gap> AperyListOfNumericalSemigroupWRTElement(s);
[ 6, 10, 5 ]
gap> 
'''