### PR TITLE
CI: Ensure code coverage reporting will work in February 2022 and beyond

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,11 +21,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: gap-actions/setup-gap-for-packages@v1
+      - uses: gap-actions/setup-gap@v2
         with:
           GAPBRANCH: ${{ matrix.gap-branch }}
-      - uses: gap-actions/compile-documentation-for-packages@v1
-      - uses: gap-actions/run-test-for-packages@v1
+      - uses: gap-actions/build-pkg-docs@v1
+      - uses: gap-actions/build-pkg@v1
+      - uses: gap-actions/run-pkg-tests@v2
+      - uses: gap-actions/process-coverage@v2
+      - uses: codecov/codecov-action@v2
 
   # A job to compile the manual with latex and upload it as an artifact.
   manual:
@@ -34,12 +37,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: gap-actions/setup-gap-for-packages@v1
-      - uses: gap-actions/compile-documentation-for-packages@v1
+      - uses: gap-actions/setup-gap@v2
+      - uses: gap-actions/build-pkg-docs@v1
         with:
           use-latex: 'true'
       - name: "Upload documentation"
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: manual
           path: ./doc/manual.pdf


### PR DESCRIPTION
See https://github.com/gap-actions/process-coverage/issues/10
