### PR TITLE
Turn `IsSymmetric` into a property

### DIFF
--- a/gap/irreducibles.gd
+++ b/gap/irreducibles.gd
@@ -112,9 +112,8 @@ DeclareOperation("IsIrreducible",[IsIrreducibleNumericalSemigroup]);
 ##  Checks whether or not s is a symmetric numerical semigroup.
 ##
 #############################################################################
-DeclareProperty("IsSymmetricNumericalSemigroup", IsNumericalSemigroup);
-DeclareAttribute("IsSymmetric",IsNumericalSemigroup);
-#REPORT laguna for this collission; we shold be able to use synonyms here
+DeclareProperty("IsSymmetric", IsNumericalSemigroup);
+DeclareSynonymAttr("IsSymmetricNumericalSemigroup",IsSymmetric);
 
 
 #############################################################################

--- a/gap/irreducibles.gi
+++ b/gap/irreducibles.gi
@@ -484,11 +484,6 @@ InstallMethod(IsSymmetricNumericalSemigroup,
     return GenusOfNumericalSemigroup(s)=(FrobeniusNumberOfNumericalSemigroup(s)+1)/2;
 end);
 
-InstallMethod(IsSymmetric,
-"Tests wheter the semigroup is symmetric",
-[IsNumericalSemigroup], IsSymmetricNumericalSemigroup
-);
-
 InstallTrueMethod(IsIrreducibleNumericalSemigroup, IsSymmetricNumericalSemigroup);
 
 #############################################################################


### PR DESCRIPTION
This breaks compatibility with LAGUNA versions < 3.9.4, but restores compatibility with LAGUNA >= 3.9.4...

LAGUNA 3.9.4 changed `IsSymmetric` from an attribute into a property -- with a patch by me. We did not realize that this conflict exists :-/.

This situation is a bit unfortunate. I only see two ways out:
1. revert LAGUNA to the way it was before (making those who requested the change unhappy, and I think the situation is not ideal from your point of view either)
2. plow through and update both packages, and ship the new versions together in GAP 4.12 (hopefully *soon*).

If you agree with plan 2, then it'd be great to get a new release soon after merging this (there are > 50 commits since the last release, which almost exactly <s>a year</s> two years ago, so perhaps that'd be a good idea anyway?

CC @alex-konovalov 