### PR TITLE
Fixed error in `IsAdditiveNumericalSemigroup` function

### DIFF
--- a/gap/catenary-tame.gi
+++ b/gap/catenary-tame.gi
@@ -1015,8 +1015,8 @@ InstallGlobalFunction(IsAdditiveNumericalSemigroup, function(s)
 
 	m:=MultiplicityOfNumericalSemigroup(s);
 	b:=BlowUpOfNumericalSemigroup(s);
-	return AdjustmentOfNumericalSemigroup(s)
-				=AperyListOfNumericalSemigroupWRTElement(b,m);
+	return Set(AdjustmentOfNumericalSemigroup(s))
+				=Set(AperyListOfNumericalSemigroupWRTElement(b,m));
 end);
 
 


### PR DESCRIPTION
Two elements are being compared as lists, when they should be compared as sets. Change added.