### PR TITLE
PackageInfo.g: require GAP 4.12

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -242,7 +242,7 @@ PackageDoc := rec(
 
 
 Dependencies := rec(
-  GAP := "4.7",
+  GAP := "4.12",
   NeededOtherPackages := [],
 #  SuggestedOtherPackages := [["singular","normaliz"]],
   SuggestedOtherPackages := [],


### PR DESCRIPTION
Older versions can not be tested in CI anymore, as NormalizInterface fails to build; and so it is risky to claim support for them.

---

I just pushed out a CI change to most repos in gap-packages (see commit b27ae20c5a353703f49ec68bd4530719cd8629c4), which broke CI for this repo. It turns out that you were only testing against GAP 4.12 since February 2023 (see c0e410f337fb8e7712c06a21b48a35594a0a7c3d).